### PR TITLE
Create draft releases when tags are pushed, with changelog

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,43 @@
+﻿name: tag
+on:
+  push:
+    tags: [ 'v*' ]
+env:
+  DOTNET_NOLOGO: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🤘 checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: 🏷 current
+        run: echo "CURRENT_TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - name: 🏷 since
+        run: echo "SINCE_TAG=$(git describe --abbrev=0 --tags $(git rev-list --tags --skip=1 --max-count=1))" >> $GITHUB_ENV
+      - name: 🚧 prerelease
+        run: echo "PRERELEASE=true" >> $GITHUB_ENV
+        if: contains(env.CURRENT_TAG, '-')
+
+      - name: ⚙ changelog
+        uses: faberNovel/github-changelog-generator-action@master
+        with:
+          # See https://github.com/github-changelog-generator/github-changelog-generator/wiki/Advanced-change-log-generation-examples
+          options: --token ${{ secrets.GITHUB_TOKEN }} --since-tag ${{ env.SINCE_TAG }}
+
+      - name: 😺 changelog
+        run: cat CHANGELOG.md
+
+      - name: 🖉 release
+        uses: actions/create-release@v1
+        with: 
+          release_name: ${{ env.CURRENT_TAG }}
+          tag_name: ${{ env.CURRENT_TAG }}
+          draft: true
+          prerelease: ${{ env.PRERELEASE }}
+          body_path: CHANGELOG.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github_changelog_generator
+++ b/.github_changelog_generator
@@ -1,0 +1,4 @@
+usernames-as-github-logins=true
+header-label=
+add_issues_wo_labels=false
+exclude-labels=dependencies,duplicate,question,invalid,wontfix

--- a/ThisAssembly.sln
+++ b/ThisAssembly.sln
@@ -9,7 +9,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		src\Directory.Build.props = src\Directory.Build.props
 		src\Directory.Build.targets = src\Directory.Build.targets
-		README.md = README.md
+		readme.md = readme.md
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ThisAssembly", "src\ThisAssembly\ThisAssembly.csproj", "{D3A47732-4937-4B6E-BCD1-66896D04E20D}"
@@ -22,9 +22,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ThisAssembly.Strings", "src
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{09733D87-085D-4857-A556-5D28796CC138}"
 	ProjectSection(SolutionItems) = preProject
+		.github_changelog_generator = .github_changelog_generator
 		.github\workflows\build.yml = .github\workflows\build.yml
 		.github\dependabot.yml = .github\dependabot.yml
 		.github\workflows\release.yml = .github\workflows\release.yml
+		.github\workflows\tag.yml = .github\workflows\tag.yml
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ThisAssembly.Prerequisites", "src\ThisAssembly.Prerequisites\ThisAssembly.Prerequisites.csproj", "{568E5150-84AD-4619-BEA3-AA5EDF084ABC}"


### PR DESCRIPTION
Auto-generate a changelog when drafting a release, so it's easier for users to determine what features exist in a given release.

Fixes #19